### PR TITLE
Drop fruitcake/laravel-cors. Segmentation fault (core dumped)

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -75,7 +75,7 @@ class Plugin extends PluginBase
     public function register()
     {
         $this->app->register(\RLuders\Cors\Providers\CorsServiceProvider::class);
-        $this->app['router']->middleware('cors', \Fruitcake\Cors\HandleCors::class);
-        $this->app['router']->prependMiddlewareToGroup('api', \Fruitcake\Cors\HandleCors::class);
+        $this->app['router']->middleware('cors', \Illuminate\Http\Middleware\HandleCors::class);
+        $this->app['router']->prependMiddlewareToGroup('api', \Illuminate\Http\Middleware\HandleCors::class);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   },
   "require": {
     "php": ">=7.2",
-    "composer/installers": "~1.0",
+    "composer/installers": "~1.0"
   },
   "minimum-stability": "dev",
   "prefer-stable": true

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
   "require": {
     "php": ">=7.2",
     "composer/installers": "~1.0",
-    "fruitcake/laravel-cors": "~2.0"
   },
   "minimum-stability": "dev",
   "prefer-stable": true

--- a/providers/CorsServiceProvider.php
+++ b/providers/CorsServiceProvider.php
@@ -41,7 +41,7 @@ class CorsServiceProvider extends BaseServiceProvider
         $this->loadConfiguration();
 
         $kernel = $this->app->make(Kernel::class);
-        $this->app['router']->middleware('cors', \Fruitcake\Cors\HandleCors::class);
+        $this->app['router']->middleware('cors', \Illuminate\Http\Middleware\HandleCors::class);
     }
 
     /**


### PR DESCRIPTION
Hi! According to https://github.com/fruitcake/laravel-cors the package is dropped in favor of Laravel's CORS. To be honest I haven't tested these changes. I just followed the "Steps to upgrade:" from `README.md` of fruitcake/laravel-cors. Feel free to adjust them accordingly.

Currently I receive `Segmentation fault (core dumped)` after installing this plugin (Winter 1.2.1, PHP 8.1.2, Laravel 9.52). I hoped that dropping of fruitcake will help to overcome this problem.